### PR TITLE
Remove independent management of dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,13 +25,9 @@
         <karate.version>1.5.0.RC4</karate.version>
         <graal.version>24.0.0</graal.version>
         <quarkiverse.version>3.0.0</quarkiverse.version>
-        <hamcrest.version>2.2</hamcrest.version>
         <rdf4j.version>4.3.11</rdf4j.version>
         <semargl.version>0.7</semargl.version>
-        <jakarta.version>3.1.0</jakarta.version>
         <jersey.version>3.1.6</jersey.version>
-        <jose4j.version>0.9.6</jose4j.version>
-        <commons.text.version>1.12.0</commons.text.version>
         <commons.cli.version>1.7.0</commons.cli.version>
         <wiremock.version>2.35.2</wiremock.version>
         <hashids.version>1.0.3</hashids.version>
@@ -130,7 +126,6 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>${jakarta.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
@@ -140,12 +135,10 @@
         <dependency>
             <groupId>org.bitbucket.b_c</groupId>
             <artifactId>jose4j</artifactId>
-            <version>${jose4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-            <version>${commons.text.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -236,7 +229,6 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
-            <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This project currently imports the Quarkus BOM, which means that many of the current dependencies do not need to be managed independently