### PR TITLE
Update Vulnz library

### DIFF
--- a/.github/workflows/nvd-cache.yml
+++ b/.github/workflows/nvd-cache.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           repository: jeremylong/Open-Vulnerability-Project
           path: ovp
-          ref: v6.0.0
+          ref: v6.1.2
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4


### PR DESCRIPTION
This upgrades vulnz to 6.1.2.

See https://github.com/jeremylong/Open-Vulnerability-Project/issues/182#issuecomment-2217240038 for more context