### PR TITLE
Update deprecated quarkus annotation

### DIFF
--- a/src/test/java/org/solid/testharness/http/AuthManagerTest.java
+++ b/src/test/java/org/solid/testharness/http/AuthManagerTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 @QuarkusTest
-@WithTestResource(value = AuthenticationResource.class)
+@WithTestResource(AuthenticationResource.class)
 class AuthManagerTest {
     public static final Map<String, String> ALICE_WEBID_MAP = Map.of(HttpConstants.ALICE,
             "https://alice.target.example.org/profile/card#me");

--- a/src/test/java/org/solid/testharness/http/AuthManagerTest.java
+++ b/src/test/java/org/solid/testharness/http/AuthManagerTest.java
@@ -24,7 +24,7 @@
 package org.solid.testharness.http;
 
 import io.quarkus.test.InjectMock;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 @QuarkusTest
-@QuarkusTestResource(AuthenticationResource.class)
+@WithTestResource(value = AuthenticationResource.class)
 class AuthManagerTest {
     public static final Map<String, String> ALICE_WEBID_MAP = Map.of(HttpConstants.ALICE,
             "https://alice.target.example.org/profile/card#me");

--- a/src/test/java/org/solid/testharness/http/ClientTest.java
+++ b/src/test/java/org/solid/testharness/http/ClientTest.java
@@ -52,7 +52,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @QuarkusTest
-@WithTestResource(value = ClientResource.class)
+@WithTestResource(ClientResource.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ClientTest {
     private static final URI TEST_URL = URI.create(TestUtils.SAMPLE_BASE);

--- a/src/test/java/org/solid/testharness/http/ClientTest.java
+++ b/src/test/java/org/solid/testharness/http/ClientTest.java
@@ -25,7 +25,7 @@ package org.solid.testharness.http;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.common.WithTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.jose4j.jwk.JsonWebKeySet;
 import org.junit.jupiter.api.BeforeAll;
@@ -52,7 +52,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @QuarkusTest
-@QuarkusTestResource(ClientResource.class)
+@WithTestResource(value = ClientResource.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ClientTest {
     private static final URI TEST_URL = URI.create(TestUtils.SAMPLE_BASE);


### PR DESCRIPTION
With the Quarkus 3.13 update, the QuarkusTestResource annotation has been deprecated in favour of WithTestResource. This updates our use of the annotation.